### PR TITLE
Update role to use namespace parameter

### DIFF
--- a/deploy-template.yaml
+++ b/deploy-template.yaml
@@ -33,7 +33,7 @@ objects:
   metadata:
     creationTimestamp: null
     name: ${AGNOSTICV_NAME}
-    namespace: ${AGNOSTICV_NAME}
+    namespace: ${AGNOSTICV_NAMESPACE}
   rules:
   - apiGroups:
     - ""


### PR DESCRIPTION
Currently the role in `deploy-template.yaml` uses the `AGNOSTICV_NAME` as both the name and namespace. This PR updates the role to use the `AGNOSTICV_NAMESPACE` param.

cc/ @pabrahamsson @oybed