### PR TITLE
Allow secrets in agnosticv to be a dictionary

### DIFF
--- a/roles/agnosticv/templates/governor.yaml.j2
+++ b/roles/agnosticv/templates/governor.yaml.j2
@@ -46,8 +46,8 @@ spec:
 {% for secret in vars.merged_vars.__meta__.secrets | default([]) %}
   {% if secret is mapping %}
     {% if 'name' in secret %}
-    {% set sname = secret.name | replace('_', '-') %}
-  - {{ secret | combine({'var':'job_vars','name':sname}) | to_json }}
+    {% set sanitized_name = secret.name | replace('_', '-') %}
+  - {{ secret | combine({'var':'job_vars','name':sanitized_name}) | to_json }}
     {% endif %}
   {% else %}
   - name: {{ secret | replace('_', '-') | to_json }}

--- a/roles/agnosticv/templates/governor.yaml.j2
+++ b/roles/agnosticv/templates/governor.yaml.j2
@@ -1,4 +1,3 @@
-#jinja2: lstrip_blocks: "True"
 ---
 apiVersion: anarchy.gpte.redhat.com/v1
 kind: AnarchyGovernor
@@ -44,16 +43,18 @@ spec:
   - name: babylon-tower
     var: babylon_tower
 {% for secret in vars.merged_vars.__meta__.secrets | default([]) %}
-  {% if secret is mapping %}
-    {% if 'name' in secret %}
-    {% set sanitized_name = secret.name | replace('_', '-') %}
-  - {{ secret | combine({'var':'job_vars','name':sanitized_name}) | to_json }}
-    {% endif %}
-  {% else %}
+{%   if secret is mapping %}
+{%     if 'name' in secret %}
+  - name: {{ secret.name | replace('_', '-') | to_json }}
+    var: job_vars
+{%       if 'namespace' in secret %}
+    namespace: {{ secret.namespace | to_json }}
+{%       endif %}
+{%     endif %}
+{%   else %}
   - name: {{ secret | replace('_', '-') | to_json }}
     var: job_vars
-  {% endif %}
-{% endfor %}
+{%   endif %}
 
 {% raw %}
   subjectEventHandlers:

--- a/roles/agnosticv/templates/governor.yaml.j2
+++ b/roles/agnosticv/templates/governor.yaml.j2
@@ -55,6 +55,7 @@ spec:
   - name: {{ secret | replace('_', '-') | to_json }}
     var: job_vars
 {%   endif %}
+{% endfor %}
 
 {% raw %}
   subjectEventHandlers:

--- a/roles/agnosticv/templates/governor.yaml.j2
+++ b/roles/agnosticv/templates/governor.yaml.j2
@@ -43,8 +43,12 @@ spec:
   - name: babylon-tower
     var: babylon_tower
 {% for secret in vars.merged_vars.__meta__.secrets | default([]) %}
+  {% if secret is mapping %}
+  - {{ secret | combine({'var':'job_vars'}) | to_json }}
+  {% else %}
   - name: {{ secret | to_json }}
     var: job_vars
+  {% endif %}
 {% endfor %}
 
 {% raw %}

--- a/roles/agnosticv/templates/governor.yaml.j2
+++ b/roles/agnosticv/templates/governor.yaml.j2
@@ -1,3 +1,4 @@
+#jinja2: lstrip_blocks: "True"
 ---
 apiVersion: anarchy.gpte.redhat.com/v1
 kind: AnarchyGovernor

--- a/roles/agnosticv/templates/governor.yaml.j2
+++ b/roles/agnosticv/templates/governor.yaml.j2
@@ -45,9 +45,12 @@ spec:
     var: babylon_tower
 {% for secret in vars.merged_vars.__meta__.secrets | default([]) %}
   {% if secret is mapping %}
-  - {{ secret | combine({'var':'job_vars'}) | to_json }}
+    {% if 'name' in secret %}
+    {% set sname = secret.name | replace('_', '-') %}
+  - {{ secret | combine({'var':'job_vars','name':sname}) | to_json }}
+    {% endif %}
   {% else %}
-  - name: {{ secret | to_json }}
+  - name: {{ secret | replace('_', '-') | to_json }}
     var: job_vars
   {% endif %}
 {% endfor %}


### PR DESCRIPTION
This commit if applied will allow secrets to be a dictionary in agnosticv.

This allows things like specifying the namespace the secret is from.

example:

```yaml
  __meta__:
    secrets:
      - name: gpte
        namespace: gpte
```