### PR TITLE
Remove hard coded namespaces

### DIFF
--- a/roles/agnosticv/tasks/generate_catalog_item.yml
+++ b/roles/agnosticv/tasks/generate_catalog_item.yml
@@ -19,7 +19,7 @@
         catalog_item_name: "{{ account | replace('_', '-') }}.{{ catalog_item | lower | regex_replace('_', '-') }}.{{ stage }}"
 
     - set_fact:
-        _namespace: "agnosticv-operator"
+        _namespace: "{{ lookup('env','WATCH_NAMESPACE') }}"
 
     - name: Use namespace defined in the catalog item YAML
       set_fact:
@@ -52,7 +52,7 @@
         api_version: anarchy.gpte.redhat.com/v1
         kind: AnarchyGovernor
         name: "{{ catalog_item_name }}"
-        namespace: anarchy-operator
+        namespace: "{{ _namespace }}"
       register: governor_facts
 
     - name: Generate Catalog item governor

--- a/roles/agnosticv/tasks/main.yml
+++ b/roles/agnosticv/tasks/main.yml
@@ -20,7 +20,7 @@
         api_version: v1
         kind: Secret
         name: "{{ ssh_key }}"
-        namespace: agnosticv-operator
+        namespace: "{{ lookup('env','WATCH_NAMESPACE') }}"
       register: ssh_key_r
       no_log: true
 

--- a/roles/agnosticv/templates/governor.yaml.j2
+++ b/roles/agnosticv/templates/governor.yaml.j2
@@ -3,8 +3,10 @@ apiVersion: anarchy.gpte.redhat.com/v1
 kind: AnarchyGovernor
 metadata:
   name: {{ _name }}
-  namespace: anarchy-operator
+  namespace: {{ lookup('env','WATCH_NAMESPACE') }}
+{% if current_resource_version != '' %}
   resourceVersion: "{{ current_resource_version }}"
+{% endif %}
 spec:
   ansibleGalaxyRequirements:
     roles:


### PR DESCRIPTION
This removes hard coded namespaces in a few places which allows for more control over how you deploy agnosticv-operator.
I also had to add a conditional for the resourceVersion since I was getting errors if it was an empty string (on creation).