### PR TITLE
Add GPTE Reporting

### DIFF
--- a/roles/agnosticv/defaults/main.yml
+++ b/roles/agnosticv/defaults/main.yml
@@ -14,5 +14,10 @@ output_dir: /tmp/output_dir
 
 babylon_anarchy_governor_repo: https://github.com/redhat-gpte-devopsautomation/babylon_anarchy_governor.git
 babylon_anarchy_governor_version: master
+
 babylon_aws_sandbox_repo: https://github.com/redhat-gpte-devopsautomation/babylon_aws_sandbox.git
 babylon_aws_sandbox_version: master
+
+gpte_reporting: false
+babylon_gpte_reporting_repo: https://github.com/redhat-gpte-devopsautomation/babylon_gpte_reporting.git
+babylon_gpte_reporting_version: master

--- a/roles/agnosticv/tasks/generate_catalog_item.yml
+++ b/roles/agnosticv/tasks/generate_catalog_item.yml
@@ -5,6 +5,8 @@
 
 - include_tasks: include_vars.yml
 
+- include_tasks: specified_behaviors.yml
+
 # If the catalog item defines some __meta__ then it's a candidate
 - when:
   - "'__meta__' in merged_vars"

--- a/roles/agnosticv/tasks/specified_behaviors.yml
+++ b/roles/agnosticv/tasks/specified_behaviors.yml
@@ -1,0 +1,14 @@
+---
+# GPTE Reporting
+# Detect if reporting is needed for that catalog item.
+- name: GPTE Reporting is enabled
+  when: >-
+    {{ 'gpte_db' in
+    merged_vars.__meta__.secrets
+    | default([])
+    | selectattr('var', 'defined')
+    | list
+    | json_query('[].var') }}
+
+  set_fact:
+    gpte_reporting: true

--- a/roles/agnosticv/templates/governor.yaml.j2
+++ b/roles/agnosticv/templates/governor.yaml.j2
@@ -12,6 +12,11 @@ spec:
     - name: babylon_anarchy_governor
       src: {{ ('git+' ~ babylon_anarchy_governor_repo) | to_json }}
       version: {{ babylon_anarchy_governor_version | to_json }}
+{% if gpte_reporting %}
+    - name: babylon_gpte_reporting
+      src: {{ ('git+' ~ babylon_gpte_reporting_repo) | to_json }}
+      version: {{ babylon_gpte_reporting_version | to_json }}
+{% endif %}
 {% if merged_vars.__meta__.aws_sandboxed | default(false) %}
     - name: babylon_aws_sandbox
       src: {{ ('git+' ~ babylon_aws_sandbox_repo) | to_json }}
@@ -80,9 +85,15 @@ spec:
         # anarchy_action_callback_data
         started:
           roles:
+{% if gpte_reporting %}
+          - role: babylon_gpte_reporting
+{% endif %}
           - role: babylon_anarchy_governor
         complete:
           roles:
+{% if gpte_reporting %}
+          - role: babylon_gpte_reporting
+{% endif %}
           - role: babylon_anarchy_governor
     stop:
       roles:


### PR DESCRIPTION
This commit, if applied, will update the governor template in order to load the
babylon roles that does GPTE reporting.

When a secret targeting the var `gpte_db` is present in `__meta__.secrets` then
reporting is enabled.

This is specific to GPTE but it's disabled by default.