### PR TITLE
Add python requirement for packaging

### DIFF
--- a/roles/agnosticv/templates/governor.yaml.j2
+++ b/roles/agnosticv/templates/governor.yaml.j2
@@ -12,6 +12,7 @@ spec:
     roles: {{ babylon_anarchy_roles | to_json }}
   pythonRequirements: |
     awscli==1.18.92
+    packaging==20.9
     pymysql==0.9.3
   vars:
     # Flags to modify scheduled action behavior


### PR DESCRIPTION
This is required for version comparison used by `__meta__.deployer.git_tag_prefix`.