### PR TITLE
Update github publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -8,20 +8,39 @@ on:
     - 'v[0-9]*'
 jobs:
   publish:
+    env:
+      IMAGE_NAME: agnosticv-operator
     runs-on: ubuntu-latest
     steps:
     - name: Checkout source
-      uses: actions/checkout@master
+      uses: actions/checkout@v2
 
-    - name: Get the version
-      id: get_version
+    - name: Set image tags
+      id: image_tags
       run: |
-        # Version is based on a semantic version tag
-        VERSION=${GITHUB_REF#refs/tags/}
-        # Publish to latest, minor, and patch tags
-        TAGS=('latest' "${VERSION}" "${VERSION%.*}")
-        # Set IMAGE_TAGS output for use in next step
-        ( IFS=$','; echo "::set-output name=IMAGE_TAGS::${TAGS[*]}" )
+        # Version is a semantic version tag or semantic version with release number
+        # GITHUB_REF will be of the form "refs/tags/v0.1.2" or "refs/tags/v0.1.2-1"
+        # To determine RELEASE, strip off the leading "refs/tags/"
+        RELEASE=${GITHUB_REF#refs/tags/}
+        # To determine VERSION, strip off any release number suffix
+        VERSION=${RELEASE/-*/}
+        echo "::set-output name=RELEASE::${RELEASE}"
+        echo "::set-output name=VERSION::${VERSION}"
+
+        # Only build image if version tag without release number
+        # Releases indicate a change in the repository that should not trigger a new build.
+        if [[ "${VERSION}" == "${RELEASE}" ]]; then
+          # Publish to latest, minor, and patch tags
+          # Ex: latest,v0.1.2,v0.1
+          IMAGE_TAGS=(
+            '${{ secrets.REGISTRY_URI }}/${{ secrets.REGISTRY_REPOSITORY }}/${{ env.IMAGE_NAME }}:latest'
+            "${{ secrets.REGISTRY_URI }}/${{ secrets.REGISTRY_REPOSITORY }}/${{ env.IMAGE_NAME }}:${VERSION%.*}"
+            "${{ secrets.REGISTRY_URI }}/${{ secrets.REGISTRY_REPOSITORY }}/${{ env.IMAGE_NAME }}:${VERSION}"
+          )
+          # Set IMAGE_TAGS output for use in next step
+          ( IFS=$','; echo "::set-output name=IMAGE_TAGS::${IMAGE_TAGS[*]}" )
+        fi
+
         # Read version from helm/Chart.yaml
         HELM_CHART_VERSION=$(sed -nr 's/^appVersion: (.*)/\1/p' helm/Chart.yaml)
         if [[ "v${HELM_CHART_VERSION}" != "${VERSION}" ]]; then
@@ -29,12 +48,22 @@ jobs:
           exit 1
         fi
 
-    - name: Build and publish image
-      uses: docker/build-push-action@v1
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+      if: steps.image_tags.outputs.IMAGE_TAGS
+
+    - name: Login to Image Registry
+      uses: docker/login-action@v1
+      if: steps.image_tags.outputs.IMAGE_TAGS
       with:
-        dockerfile: build/Dockerfile
         registry: ${{ secrets.REGISTRY_URI }}
-        repository: ${{ secrets.REGISTRY_REPOSITORY }}/agnosticv-operator
         username: ${{ secrets.REGISTRY_USERNAME }}
         password: ${{ secrets.REGISTRY_PASSWORD }}
-        tags: "${{ steps.get_version.outputs.IMAGE_TAGS }}"
+
+    - name: Build and publish image to Quay
+      uses: docker/build-push-action@v2
+      if: steps.image_tags.outputs.IMAGE_TAGS
+      with:
+        file: Dockerfile
+        push: true
+        tags: ${{ steps.image_tags.outputs.IMAGE_TAGS }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -64,6 +64,6 @@ jobs:
       uses: docker/build-push-action@v2
       if: steps.image_tags.outputs.IMAGE_TAGS
       with:
-        file: Dockerfile
+        file: build/Dockerfile
         push: true
         tags: ${{ steps.image_tags.outputs.IMAGE_TAGS }}


### PR DESCRIPTION
The `docker/build-push-action@v1` action has been disabled and we need to update to `docker/build-push-action@v2`. This update is virtually identical to our setup for our other builds.