### PR TITLE
Fix the default branch for babylon_anarchy_governor

### DIFF
--- a/roles/agnosticv/defaults/main.yml
+++ b/roles/agnosticv/defaults/main.yml
@@ -21,7 +21,7 @@ babylon_anarchy_collections:
 babylon_anarchy_roles:
 - name: babylon_anarchy_governor
   src: https://github.com/redhat-gpte-devopsautomation/babylon_anarchy_governor.git
-  version: master
+  version: main
 
 # AgnosticV CLI
 agnosticv_client_path: /opt/ansible/agnosticv_cli


### PR DESCRIPTION
The `babylon_anarchy_governor` repo switched to using `main` as the default branch. This PR aligns with this new branch name. 