### PR TITLE
Update agnosticvrepo examples and default values to match Ansible roles

### DIFF
--- a/deploy-agnosticvrepo.yaml
+++ b/deploy-agnosticvrepo.yaml
@@ -20,7 +20,7 @@ parameters:
   value: https://github.com/redhat-gpte-devopsautomation/babylon_anarchy_governor.git
 - name: BABYLON_ANARCHY_GOVERNOR_VERSION
   description: Git reference for babylon governor repository
-  value: master
+  value: main
 
 objects:
 - apiVersion: gpte.redhat.com/v1
@@ -31,5 +31,8 @@ objects:
     url: ${AGNOSTICV_SCM_URL}
     ref: ${AGNOSTICV_SCM_REF}
     sshKey: ${AGNOSTICV_SCM_SSH_KEY_SECRET}
-    babylonAnarchyGovernorRepo: ${BABYLON_ANARCHY_GOVERNOR_REPO}
-    babylonAnarchyGovernorVersion: ${BABYLON_ANARCHY_GOVERNOR_VERSION}
+    babylon_anarchy_roles:
+    - name: babylon_anarchy_governor
+      src: ${BABYLON_ANARCHY_GOVERNOR_REPO}
+      version: ${BABYLON_ANARCHY_GOVERNOR_VERSION}
+

--- a/deploy/crds/gpte_v1_agnosticvrepo_cr.yaml
+++ b/deploy/crds/gpte_v1_agnosticvrepo_cr.yaml
@@ -6,5 +6,8 @@ spec:
   url: git@github.com:redhat-gpe/agnosticv.git
   ref: master
   sshKey: agnosticv-operator-sshkey
-  babylonAnarchyGovernorRepo: https://github.com/redhat-gpte-devopsautomation/babylon_anarchy_governor.git
-  babylonAnarchyGovernorVersion: master
+  babylon_anarchy_roles:
+  - name: babylon_anarchy_governor
+    src: https://github.com/redhat-gpte-devopsautomation/babylon_anarchy_governor.git
+    version: main
+

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -29,7 +29,7 @@ anarchy:
 babylonAnarchyRoles:
 - name: anarchy
   src: https://github.com/redhat-gpte-devopsautomation/babylon_anarchy_governor.git
-  version: master
+  version: main
 
 replicaCount: 1
 

--- a/readme.adoc
+++ b/readme.adoc
@@ -131,8 +131,10 @@ spec:
   ref: master
   sshKey: agnosticv-operator-sshkey
   url: git@github.com:redhat-gpe/agnosticv.git
-  babylonAnarchyGovernorRepo: https://github.com/redhat-gpte-devopsautomation/babylon_anarchy_governor.git
-  babylonAnarchyGovernorVersion: master
+  babylon_anarchy_roles:
+  - name: babylon_anarchy_governor
+    src: https://github.com/redhat-gpte-devopsautomation/babylon_anarchy_governor.git
+    version: main
 ----
 
 [source,shell]


### PR DESCRIPTION
@jkupferer @fridim 

Hey there, just a few more updates on the babylon_anarchy_governor version. It seems that in addition to the `main` branch rename the docs and examples have drifted a bit from the playbooks which consume this dict.

This should bring us up to date! Thanks.