### PR TITLE
Draft: Add contextDir for AgnosticVRepos

### DIFF
--- a/deploy-agnosticvrepo.yaml
+++ b/deploy-agnosticvrepo.yaml
@@ -15,6 +15,8 @@ parameters:
   value: master
 - name: AGNOSTICV_SCM_SSH_KEY_SECRET
   value: agnosticv-repo-sshkey
+- name: AGNOSTICV_SCM_CONTEXT_DIR
+  required: false
 - name: BABYLON_ANARCHY_GOVERNOR_REPO
   description: Git repository for Ansible role containing Babylon AnarchyGovernor logic
   value: https://github.com/redhat-gpte-devopsautomation/babylon_anarchy_governor.git
@@ -30,6 +32,7 @@ objects:
   spec:
     url: ${AGNOSTICV_SCM_URL}
     ref: ${AGNOSTICV_SCM_REF}
+    contextDir: ${AGNOSTICV_SCM_CONTEXT_DIR}
     sshKey: ${AGNOSTICV_SCM_SSH_KEY_SECRET}
     babylon_anarchy_roles:
     - name: babylon_anarchy_governor

--- a/deploy/crds/gpte_v1_agnosticvrepo_cr.yaml
+++ b/deploy/crds/gpte_v1_agnosticvrepo_cr.yaml
@@ -6,6 +6,7 @@ spec:
   url: git@github.com:redhat-gpe/agnosticv.git
   ref: master
   sshKey: agnosticv-operator-sshkey
+  contextDir: ''
   babylon_anarchy_roles:
   - name: babylon_anarchy_governor
     src: https://github.com/redhat-gpte-devopsautomation/babylon_anarchy_governor.git

--- a/helm/templates/agnosticvrepos.yaml
+++ b/helm/templates/agnosticvrepos.yaml
@@ -8,6 +8,7 @@ metadata:
 spec:
   ref: {{ $agnosticvRepo.ref | default "master" | quote }}
   url: {{ $agnosticvRepo.url | quote }}
+  contextDir: {{ $agnosticvRepo.contextDir | quote }}
   babylonAnarchyRoles: 
     {{- toYaml $.Values.babylonAnarchyRoles | nindent 4 }}
   {{- with $agnosticvRepo.sshKey }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -17,6 +17,7 @@ image:
 #- name: gpte-agnosticv
 #  url: git@github.com:redhat-gpe/agnosticv.git
 #  ref: master
+#  contextDir: ''
 #  sshKey: |
 #    -----BEGIN RSA PRIVATE KEY-----
 #    ...

--- a/readme.adoc
+++ b/readme.adoc
@@ -131,6 +131,7 @@ spec:
   ref: master
   sshKey: agnosticv-operator-sshkey
   url: git@github.com:redhat-gpe/agnosticv.git
+  contextDir: ''
   babylon_anarchy_roles:
   - name: babylon_anarchy_governor
     src: https://github.com/redhat-gpte-devopsautomation/babylon_anarchy_governor.git

--- a/roles/agnosticv/defaults/main.yml
+++ b/roles/agnosticv/defaults/main.yml
@@ -10,6 +10,7 @@ default_labels:
   generated_by: agnosticv
 
 repo_path: /opt/ansible/agnosticv/{{ url | b64encode }}
+repo_context_dir: ''
 output_dir: /tmp/output_dir
 
 # Ansible collections to install with AnsibleGalaxy

--- a/roles/agnosticv/tasks/include_vars.yml
+++ b/roles/agnosticv/tasks/include_vars.yml
@@ -3,7 +3,7 @@
   command: >-
     {{ agnosticv_client_path }} --merge {{ c_i }}
   args:
-    chdir: "{{ repo_path }}"
+    chdir: "{{ (repo_path, repo_context_dir) | join('/') }}"
   register:
     r_agnosticv_client_merge
 

--- a/roles/agnosticv/tasks/main.yml
+++ b/roles/agnosticv/tasks/main.yml
@@ -56,6 +56,8 @@
     dest: "{{ repo_path }}"
   register: r_git_public
 
+- when: contextDir
+
 - when: >-
     r_git_private is changed
     or r_git_public is changed
@@ -79,7 +81,7 @@
       command: >-
         {{ agnosticv_client_path }} --list --has __meta__.catalog
       args:
-        chdir: "{{ repo_path }}"
+        chdir: "{{ (repo_path, repo_context_dir) | join('/') }}"
       register: r_catalogitems
 
     - loop: "{{ r_catalogitems.stdout_lines }}"


### PR DESCRIPTION
Hey @jkupferer @fridim I am starts this in draft as I am sure there is still a piece missing. The Ansible, Helm and Template stuff is about ready to go, but...

I am still not 100% certain where I can translate `AgnosticVRepo.spec.contextDir` to an Ansible var such as `repo_context_dir` to set this through the CRD.