### PR TITLE
Add chart publishing to publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -67,3 +67,40 @@ jobs:
         file: build/Dockerfile
         push: true
         tags: ${{ steps.image_tags.outputs.IMAGE_TAGS }}
+  publish-helm-charts:
+    needs: publish
+    env:
+      IMAGE_NAME: agnosticv-operator
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Source
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Checkout gh-pages
+      uses: actions/checkout@v2
+      with:
+        ref: gh-pages
+        path: gh-pages
+
+    - name: Configure Helm
+      uses: azure/setup-helm@v1
+      with:
+        version: latest
+
+    - name: Package Helm Chart
+      run: |
+        helm dep up helm/
+        helm package helm/
+        mv ${{ env.IMAGE_NAME }}-*.tgz gh-pages
+        helm repo index --url https://redhat-cop.github.io/${{ env.IMAGE_NAME }} gh-pages
+
+    - name: Push Changes to GH Pages
+      run: |
+        cd gh-pages
+        git config user.name "$GITHUB_ACTOR"
+        git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+        git add .
+        git commit -m "Updating Helm Chart Repository"
+        git push


### PR DESCRIPTION
THIS PR adds helm chart publishing to a branch called gh-pages to the existing publish workflow as a second job in the workflow that depends on the initial publish job completing successfully.

For reference, you can see this working here:

https://github.com/tylerauerbeck/anarchy/actions/runs/778974340
https://github.com/tylerauerbeck/anarchy/tree/gh-pages

This depends on there being a branch called gh-pages to publish to. Each time this job runs, it will publish a new tarball of that helm chart to the gh-pages branch and update the helm repo index.

cc/ @jkupferer