### PR TITLE
Fix error when context_dir is None

### DIFF
--- a/roles/agnosticv/tasks/main.yml
+++ b/roles/agnosticv/tasks/main.yml
@@ -79,7 +79,12 @@
       command: >-
         {{ agnosticv_client_path }} --list --has __meta__.catalog
       args:
-        chdir: "{{ (repo_path, context_dir) | join('/') }}"
+        chdir: >-
+          {%- if context_dir is defined and context_dir is not none -%}
+          {{ (repo_path, context_dir) | join('/') }}
+          {%- else -%}
+          {{ repo_path }}
+          {%- endif -%}
       register: r_catalogitems
 
     - name: Print stderr lines


### PR DESCRIPTION
Fix the error:

```
TASK [Find all catalog items] ********************************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Unable to change directory before execution: [Errno 2] No such file or directory: b'/opt/ansible/agnosticv/Z2l0QGdpdGh1Yi5jb206cmVkaGF0LWdwZS9hZ25vc3RpY3YuZ2l0/None'"}
```