### PR TITLE
Process only catalog items that changed in Git

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/operator-framework/ansible-operator:v1.7.0
+FROM quay.io/operator-framework/ansible-operator:v1.9.0
 
 USER root
 

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.10.1
+version: 0.11.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 0.10.1
+appVersion: 0.11.0

--- a/roles/agnosticv/defaults/main.yml
+++ b/roles/agnosticv/defaults/main.yml
@@ -11,6 +11,12 @@ default_labels:
 
 repo_path: /opt/ansible/agnosticv/{{ url | b64encode }}
 context_dir: ''
+
+# Process only catalog items that changed in git
+# Set this to false if you want to process all catalog items
+# all the time.
+process_changes_only: true
+
 output_dir: /tmp/output_dir
 
 # Ansible collections to install with AnsibleGalaxy

--- a/roles/agnosticv/tasks/generate_catalog_item_tasks.yml
+++ b/roles/agnosticv/tasks/generate_catalog_item_tasks.yml
@@ -7,42 +7,10 @@
 - name: Use namespace defined in the catalog item YAML
   set_fact:
     anarchy_namespace: >-
-      {{ merged_vars.__meta__.anarchy.namespace | default(default_anarchy_namespace) }}
+      {{ merged_vars.__meta__.anarchy.namespace
+      | default(default_anarchy_namespace) }}
     catalog_item_namespace: >-
       {{ merged_vars.__meta__.catalog.namespace | default('openshift') }}
-
-- name: Get k8s fact for the catalog item
-  k8s_info:
-    api_version: babylon.gpte.redhat.com/v1
-    kind: catalogitems
-    name: "{{ catalog_item_name }}"
-    namespace: "{{ catalog_item_namespace }}"
-  register: catalogitems_facts
-
-- name: Get k8s fact for the template
-  k8s_info:
-    api_version: template.openshift.io/v1
-    kind: templates
-    name: "{{ catalog_item_name }}"
-    namespace: "{{ catalog_item_namespace }}"
-  register: template_facts
-
-- name: Get k8s fact for the Governor
-  k8s_info:
-    api_version: anarchy.gpte.redhat.com/v1
-    kind: AnarchyGovernor
-    name: "{{ catalog_item_name }}"
-    namespace: "{{ anarchy_namespace }}"
-  register: governor_facts
-
-
-- name: Get k8s fact for the ResourceProvider
-  k8s_info:
-    api_version: poolboy.gpte.redhat.com/v1
-    kind: ResourceProvider
-    name: "{{ catalog_item_name }}"
-    namespace: "{{ poolboy_namespace }}"
-  register: resource_provider_facts
 
 - name: Create Namespace
   k8s:
@@ -58,7 +26,7 @@
   k8s:
     state: present
     definition: "{{ lookup('template', 'template.yml.j2' ) | from_yaml }}"
-    force: true
+    apply: true
   vars:
     _name: "{{ catalog_item_name }}"
     _namespace: "{{ catalog_item_namespace }}"
@@ -72,15 +40,12 @@
       | default(merged_vars.__meta__.catalog.description, true)
       | default(default_description)
       }}
-    current_resource_version: >-
-      {{ template_facts.resources[0].metadata.resourceVersion
-      if template_facts.resources else '' }}
 
 - name: Create / Update Babylon Catalog Item object
   k8s:
     state: present
     definition: "{{ lookup('template', 'catalog_item.yml.j2') | from_yaml }}"
-    force: true
+    apply: true
   vars:
     _catalog: "{{ merged_vars.__meta__.catalog }}"
     _namespace: "{{ catalog_item_namespace }}"
@@ -95,32 +60,23 @@
       | default(merged_vars.__meta__.catalog.description, true)
       | default(default_description)
       }}
-    current_resource_version: >-
-      {{ catalogitems_facts.resources[0].metadata.resourceVersion
-      if catalogitems_facts.resources else '' }}
 
 - name: Create / Update OpenShift Governor object
   k8s:
     state: present
     definition: "{{ lookup('template', 'governor.yml.j2') | from_yaml }}"
-    force: true
+    apply: true
   vars:
     _name: "{{ catalog_item_name }}"
     _namespace: "{{ anarchy_namespace }}"
-    current_resource_version: >-
-      {{ governor_facts.resources[0].metadata.resourceVersion
-      if governor_facts.resources else '' }}
 
 - name: Create / Update Poolboy ResourceProvider
   k8s:
     state: present
     definition: "{{ lookup('template', 'resource_provider.yml.j2') | from_yaml }}"
-    force: true
+    apply: true
   vars:
     _name: "{{ catalog_item_name }}"
     _namespace: "{{ poolboy_namespace }}"
     _governor: "{{ catalog_item_name }}"
     _catalog: "{{ merged_vars.__meta__.catalog }}"
-    current_resource_version: >-
-      {{ resource_provider_facts.resources[0].metadata.resourceVersion
-      if resource_provider_facts.resources else '' }}

--- a/roles/agnosticv/tasks/main.yml
+++ b/roles/agnosticv/tasks/main.yml
@@ -76,6 +76,7 @@
         {{ r_repo.after | quote }}
       args:
         chdir: "{{ agnosticv_path }}"
+      # NOTE: git diff includes context_dir
       register: r_changed
 
     - name: Find all catalog items

--- a/roles/agnosticv/tasks/main.yml
+++ b/roles/agnosticv/tasks/main.yml
@@ -42,7 +42,6 @@
         repo: "{{ url }}"
         version: "{{ ref }}"
         dest: "{{ repo_path }}"
-        depth: 1
         key_file: /opt/ansible/.ssh/id_rsa_{{ ssh_key }}
       register: r_git_private
 
@@ -52,7 +51,6 @@
     accept_hostkey: true
     repo: "{{ url }}"
     version: "{{ ref }}"
-    depth: 1
     dest: "{{ repo_path }}"
   register: r_git_public
 
@@ -65,6 +63,20 @@
       file:
         state: directory
         path: "{{ output_dir }}"
+
+    - name: Get list of files changed
+      vars:
+        r_repo: >-
+          {{ r_git_private if r_git_private is changed
+          else r_git_public }}
+      when: r_repo.before
+      command: >-
+        git diff --name-only
+        {{ r_repo.before | quote }}
+        {{ r_repo.after | quote }}
+      args:
+        chdir: "{{ agnosticv_path }}"
+      register: r_changed
 
     - name: Find all catalog items
       command: >-
@@ -84,7 +96,32 @@
         loop_var: c_i
         label: c_i
       include_tasks: generate_catalog_item.yml
-      when: account != 'EXAMPLE_ACCOUNT'
+      # Process catalog item only if:
+      # - it changed in git
+      # - or if common.yaml changed in git
+      # - or if ACCOUNT/account.yaml changed in git
+      when: >-
+        account != 'EXAMPLE_ACCOUNT'
+        and (
+          r_changed is skipped
+
+          or
+
+          c_i | dirname in r_changed.stdout
+
+          or
+
+          ['common.yaml', 'common.yml']
+          | intersect(r_changed.stdout_lines) | length > 0
+
+          or
+
+          [ account+'/common.yaml',
+            account+'/common.yml',
+            account+'/account.yaml',
+            account+'/account.yml' ]
+          | intersect(r_changed.stdout_lines) | length > 0
+        )
       vars:
         account: "{{ c_i.split('/')[-3] }}"
         catalog_item: "{{ c_i.split('/')[-2] }}"

--- a/roles/agnosticv/tasks/main.yml
+++ b/roles/agnosticv/tasks/main.yml
@@ -69,7 +69,7 @@
         r_repo: >-
           {{ r_git_private if r_git_private is changed
           else r_git_public }}
-      when: r_repo.before
+      when: process_changes_only and r_repo.before
       command: >-
         git diff --name-only
         {{ r_repo.before | quote }}

--- a/roles/agnosticv/tasks/main.yml
+++ b/roles/agnosticv/tasks/main.yml
@@ -98,6 +98,7 @@
       include_tasks: generate_catalog_item.yml
       # Process catalog item only if:
       # - it changed in git
+      # - ACCOUNT/CATALOG_ITEM/common.yaml changed in git
       # - or if common.yaml changed in git
       # - or if ACCOUNT/account.yaml changed in git
       when: >-
@@ -107,22 +108,35 @@
 
           or
 
-          c_i | dirname in r_changed.stdout
+          context_prefix + c_i in r_changed.stdout_lines
 
           or
 
-          ['common.yaml', 'common.yml']
+          [ context_prefix + c_i | dirname +/common.yml',
+            context_prefix + c_i | dirname +/common.yaml']
           | intersect(r_changed.stdout_lines) | length > 0
 
           or
 
-          [ account+'/common.yaml',
-            account+'/common.yml',
-            account+'/account.yaml',
-            account+'/account.yml' ]
+          [ context_prefix + account+'/common.yaml',
+            context_prefix + account+'/common.yml',
+            context_prefix + account+'/account.yaml',
+            context_prefix + account+'/account.yml' ]
+          | intersect(r_changed.stdout_lines) | length > 0
+
+          or
+
+          [ context_prefix + 'common.yaml',
+            context_prefix + 'common.yml']
           | intersect(r_changed.stdout_lines) | length > 0
         )
       vars:
+        context_prefix: >-
+          {{ context_dir + '/'
+          if context_dir is defined
+          and context_dir is not none
+          and context_dir != ''
+          else '' }}
         account: "{{ c_i.split('/')[-3] }}"
         catalog_item: "{{ c_i.split('/')[-2] }}"
         stage: "{{ c_i.split('/')[-1] | regex_replace('\\.ya?ml$', '') }}"

--- a/roles/agnosticv/tasks/main.yml
+++ b/roles/agnosticv/tasks/main.yml
@@ -108,20 +108,20 @@
 
           or
 
-          context_prefix + c_i in r_changed.stdout_lines
+          (context_prefix + c_i) in r_changed.stdout_lines
 
           or
 
-          [ context_prefix + c_i | dirname +/common.yml',
-            context_prefix + c_i | dirname +/common.yaml']
+          [ context_prefix + c_i | dirname + '/common.yml',
+            context_prefix + c_i | dirname + '/common.yaml']
           | intersect(r_changed.stdout_lines) | length > 0
 
           or
 
-          [ context_prefix + account+'/common.yaml',
-            context_prefix + account+'/common.yml',
-            context_prefix + account+'/account.yaml',
-            context_prefix + account+'/account.yml' ]
+          [ context_prefix + account + '/common.yaml',
+            context_prefix + account + '/common.yml',
+            context_prefix + account + '/account.yaml',
+            context_prefix + account + '/account.yml' ]
           | intersect(r_changed.stdout_lines) | length > 0
 
           or

--- a/roles/agnosticv/templates/catalog_item.yml.j2
+++ b/roles/agnosticv/templates/catalog_item.yml.j2
@@ -17,7 +17,9 @@ metadata:
     babylon.gpte.redhat.com/{{ _label_k }}: {{ _label_v | to_json }}
 {%   endfor %}
   name: {{ _name | to_json }}
+{% if current_resource_version | default('') != '' %}
   resourceVersion: "{{ current_resource_version }}"
+{% endif %}
 spec:
   resources:
   - provider:

--- a/roles/agnosticv/templates/governor.yml.j2
+++ b/roles/agnosticv/templates/governor.yml.j2
@@ -4,7 +4,7 @@ kind: AnarchyGovernor
 metadata:
   namespace: {{ _namespace | to_json }}
   name: {{ _name }}
-{% if current_resource_version != '' %}
+{% if current_resource_version | default('') != '' %}
   resourceVersion: "{{ current_resource_version }}"
 {% endif %}
 spec:

--- a/roles/agnosticv/templates/resource_provider.yml.j2
+++ b/roles/agnosticv/templates/resource_provider.yml.j2
@@ -4,7 +4,9 @@ kind: ResourceProvider
 metadata:
   name: {{ _name | to_json }}
   namespace: {{ _namespace | to_json }}
+{% if current_resource_version | default('') != '' %}
   resourceVersion: "{{ current_resource_version }}"
+{% endif %}
 spec:
   default:
     spec:

--- a/roles/agnosticv/templates/template.yml.j2
+++ b/roles/agnosticv/templates/template.yml.j2
@@ -10,7 +10,9 @@ metadata:
     openshift.io/long-description: {{ merged_vars.__meta__.catalog.long_description | d('') | to_json }}
     tags: quickstart,babylon,{{ account | replace('_', '-') }},{{ merged_vars.__meta__.catalog.tags |  default([]) | join(',') }}
     template.openshift.io/bindable: "false"
+{% if current_resource_version | default('') != '' %}
   resourceVersion: "{{ current_resource_version }}"
+{% endif %}
   openshift.io/provider-display-name: Red Hat, Inc.
   labels:
     gpte.redhat.com/agnosticv: "true"

--- a/watches.yaml
+++ b/watches.yaml
@@ -3,4 +3,4 @@
   group: gpte.redhat.com
   kind: AgnosticVRepo
   role: /opt/ansible/roles/agnosticv
-  reconcilePeriod: 2m
+  reconcilePeriod: 1m


### PR DESCRIPTION
This change, if applied, improves agnosticv-operator performance by doing the following:

- During a cycle, only process catalog items that changed in git
- Do not call `k8s_info` to grab the resourceVersion, use the `apply: true` feature in `k8s` tasks intead.

NOTE: the operator will always process **all** catalog items at startup.

Done:
- Still process catalog items if /common.yaml or
  ACCOUNT/account.yaml has changed
- Still process *all* catalog items at startup
- Update operator framework image to latest
- Get rid of `k8s_info` tasks, use `apply: true` in k8s tasks instead
- Add a variable to enable/disable the feature `process_changes_only` boolean
- Support `context_dir`
- Bump version to 0.11.0