### PR TITLE
force update of resources  GPTEINFRA-1369

### DIFF
--- a/roles/agnosticv/tasks/main.yml
+++ b/roles/agnosticv/tasks/main.yml
@@ -105,9 +105,9 @@
       when: >-
         account != 'EXAMPLE_ACCOUNT'
         and (
-          r_changed is skipped
+          r_changed is not skipped
 
-          or
+          and (
 
           (context_prefix + c_i) in r_changed.stdout_lines
 
@@ -130,7 +130,7 @@
           [ context_prefix + 'common.yaml',
             context_prefix + 'common.yml']
           | intersect(r_changed.stdout_lines) | length > 0
-        )
+        ))
       vars:
         context_prefix: >-
           {{ context_dir + '/'


### PR DESCRIPTION
When a variable is removed from an agnosticv catalog item, the governor is not updated.

This PR is a draft, trying to address that.