### PR TITLE
Add allowUserGroups to CatalogItem

### DIFF
--- a/roles/agnosticv/templates/catalog_item.yml.j2
+++ b/roles/agnosticv/templates/catalog_item.yml.j2
@@ -33,6 +33,9 @@ metadata:
   resourceVersion: "{{ _current_resource_version }}"
 {% endif %}
 spec:
+{% if vars.merged_vars.__meta__.allow_user_groups is defined %}
+  allowUserGroups: {{ vars.merged_vars.__meta__.allow_user_groups | to_json }}
+{% endif %}
 {% if _bookbag.image is defined or _bookbag.imageBuild is defined %}
   bookbag:
 {%   if _bookbag.auth is defined %}


### PR DESCRIPTION
This PR adds `spec.allowUserGroups` to the CatalogItem. This will be used by the catalog to indicate to the user whether a catalog item may be requested. A later PR will need to add functionality relevant for Poolboy to implement access control.