### PR TITLE
Add improved catalog icon support

### DIFF
--- a/roles/agnosticv/tasks/generate_catalog_item_tasks.yml
+++ b/roles/agnosticv/tasks/generate_catalog_item_tasks.yml
@@ -82,6 +82,7 @@
     _bookbag: "{{ merged_vars.__meta__.bookbag | default({}) }}"
     _catalog: "{{ merged_vars.__meta__.catalog }}"
     _current_resource_version: "{{ r_get_catalog_item.resources[0].metadata.resourceVersion | default('') }}"
+    _icon: "{{ merged_vars.__meta__.catalog.icon | default('') }}"
     _namespace: "{{ catalog_item_namespace }}"
     _name: "{{ catalog_item_name }}"
     _stage: "{{ stage }}"
@@ -147,6 +148,7 @@
     vars:
       _catalog: "{{ vars.merged_vars.__meta__.catalog }}"
       _current_resource_version: "{{ r_get_user_catalog_item.resources[0].metadata.resourceVersion | default('') }}"
+      _icon: "{{ merged_vars.__meta__.catalog.icon | default('') }}"
       _namespace: "{{ user_catalog_item_namespace }}"
       _name: "{{ catalog_item_name }}"
       _stage: "{{ stage }}"

--- a/roles/agnosticv/templates/catalog_item.yml.j2
+++ b/roles/agnosticv/templates/catalog_item.yml.j2
@@ -8,7 +8,7 @@ metadata:
     babylon.gpte.redhat.com/description: {{ _description | to_json }}
     babylon.gpte.redhat.com/descriptionFormat: {{ _description_format | to_json }}
     babylon.gpte.redhat.com/displayName: {{ (_catalog.display_name | default(_name) ~ (' (infra)' if _catalog.multiuser | default(false) | bool else '')) | to_json }}
-    babylon.gpte.redhat.com/icon: {{ _catalog.icon | default('') | to_json }}
+    babylon.gpte.redhat.com/icon: {% if _icon is mapping %}{{ _icon | to_json | to_json }}{% else %}{{ _icon | to_json }}{% endif %}
     babylon.gpte.redhat.com/keywords: {{ _catalog.keywords | default([]) | join(',') | to_json }}
 {% for _component in vars.merged_vars.__meta__.components | default([]) %}
 {%   if _component.display_name is defined %}

--- a/roles/agnosticv/templates/user_catalog_item.yml.j2
+++ b/roles/agnosticv/templates/user_catalog_item.yml.j2
@@ -8,7 +8,7 @@ metadata:
     babylon.gpte.redhat.com/description: {{ _description | to_json }}
     babylon.gpte.redhat.com/descriptionFormat: {{ _description_format | to_json }}
     babylon.gpte.redhat.com/displayName: {{ _catalog.display_name | default(_name) | to_json }}
-    babylon.gpte.redhat.com/icon: {{ _catalog.icon | default('') | to_json }}
+    babylon.gpte.redhat.com/icon: {% if _icon is mapping %}{{ _icon | to_json | to_json }}{% else %}{{ _icon | to_json }}{% endif %}
     babylon.gpte.redhat.com/keywords: {{ _catalog.keywords | default([]) | join(',') | to_json }}
   labels:
     babylon.gpte.redhat.com/category: {{ _catalog.category | default(default_category) | to_json }}


### PR DESCRIPTION
Allow catalog icons to be configured with a dict. Such as:
```
__meta__:
  catalog:
    icon:
      alt: Icon
      url: "https://example.com/icon.svg"
      style:
        height: 100px
        width: 100px
```