### PR TITLE
Allow updateFilters in ResourceProvider template

### DIFF
--- a/roles/agnosticv/templates/resource_provider.yml.j2
+++ b/roles/agnosticv/templates/resource_provider.yml.j2
@@ -65,7 +65,7 @@ spec:
     - add
     - replace
     pathMatch: /spec/vars/desired_state
-{% for parameter in merged_vars.__meta__.catalog.parameters %}
+{% for parameter in merged_vars.__meta__.catalog.parameters | default([]) %}
 {%   if parameter.allowUpdate | default(false) | bool %}
   - pathMatch: /spec/vars/job_vars/{{ parameter.name }}(/.*)?
 {%   endif %}

--- a/roles/agnosticv/templates/resource_provider.yml.j2
+++ b/roles/agnosticv/templates/resource_provider.yml.j2
@@ -65,6 +65,13 @@ spec:
     - add
     - replace
     pathMatch: /spec/vars/desired_state
+{% if merged_vars.__meta__.catalog.parameters | default([]) | length > 0 %}
+{%   for parameter in merged_vars.__meta__.catalog.parameters %}
+{%     if allowUpdate | default(false) | bool %}
+  - pathMatch: /spec/vars/job_vars/{{ parameter.name }}(/.*)?
+{%     endif %}
+{%   endfor %}
+{% endif %}
   validation:
     openAPIV3Schema:
       type: object

--- a/roles/agnosticv/templates/resource_provider.yml.j2
+++ b/roles/agnosticv/templates/resource_provider.yml.j2
@@ -65,11 +65,11 @@ spec:
     - add
     - replace
     pathMatch: /spec/vars/desired_state
-{%   for parameter in merged_vars.__meta__.catalog.parameters %}
-{%     if parameter.allowUpdate | default(false) | bool %}
+{% for parameter in merged_vars.__meta__.catalog.parameters %}
+{%   if parameter.allowUpdate | default(false) | bool %}
   - pathMatch: /spec/vars/job_vars/{{ parameter.name }}(/.*)?
-{%     endif %}
-{%   endfor %}
+{%   endif %}
+{% endfor %}
   validation:
     openAPIV3Schema:
       type: object

--- a/roles/agnosticv/templates/resource_provider.yml.j2
+++ b/roles/agnosticv/templates/resource_provider.yml.j2
@@ -65,13 +65,11 @@ spec:
     - add
     - replace
     pathMatch: /spec/vars/desired_state
-{% if merged_vars.__meta__.catalog.parameters | default([]) | length > 0 %}
 {%   for parameter in merged_vars.__meta__.catalog.parameters %}
-{%     if allowUpdate | default(false) | bool %}
+{%     if parameter.allowUpdate | default(false) | bool %}
   - pathMatch: /spec/vars/job_vars/{{ parameter.name }}(/.*)?
 {%     endif %}
 {%   endfor %}
-{% endif %}
   validation:
     openAPIV3Schema:
       type: object


### PR DESCRIPTION
Allows a user to provide a job variable with the `allowUpdate` field and have the `updateFilters` added automatically.

Given the following AgnosticV parameter

```yaml
---
__meta__:
  catalog:
    parameters:
      - name: lodestar_identities_remove
        description: Lodestar identities to remove
        formLabel: Lodestar Identities to Remove
        allowUpdate: true
        openAPIV3Schema:
          type: object
          default: {}
```

Results in a ResourceProvider with the following `updateFilters` snippet

```yaml
  updateFilters:
  - allowedOps:
    - add
    - replace
    pathMatch: /spec/vars/action_schedule/start
  - allowedOps:
    - add
    - replace
    pathMatch: /spec/vars/action_schedule/stop
  - allowedOps:
    - add
    - replace
    pathMatch: /spec/vars/desired_state
  - pathMatch: /spec/vars/job_vars/lodestar_identities_remove(/.*)?
```
