### PR TITLE
Add updateFilters for runtime

### DIFF
--- a/roles/agnosticv/templates/resource_provider.yml.j2
+++ b/roles/agnosticv/templates/resource_provider.yml.j2
@@ -56,6 +56,14 @@ spec:
   - allowedOps:
     - add
     - replace
+    pathMatch: /spec/vars/action_schedule/default_runtime
+  - allowedOps:
+    - add
+    - replace
+    pathMatch: /spec/vars/action_schedule/maximum_runtime
+  - allowedOps:
+    - add
+    - replace
     pathMatch: /spec/vars/action_schedule/start
   - allowedOps:
     - add


### PR DESCRIPTION
# Overview

This PR adds `updateFilters` for `default_runtime` and `maximum_runtime`.

# Background

In the event that `action_schedule.start` and `action_schedule.stop` is not being used, when AgnosticV Operator generates the ResourceHandle, the `action_schedule.default_runtime` and `action_schedule.maximum_runtime` is being stripped from the ResourceHandle.

An example `ResourceProvider` snippet might look like this;

```yaml
  spec:
      governor: do500.ocp4.dev
      vars:
        action_schedule:
          default_runtime: 2h
          maximum_runtime: 4h
```

This example is missing the `start` and `stop` fields. This results in the following error as `action_schedule` is being left out of the `ResourceHandle` when generated.



```bash
# snippet
has no attribute 'action_schedule'

# full error line
File \"/opt/app-root/lib64/python3.9/site-packages/jinja2/environment.py\", line 925, in handle_exception\n    raise rewrite_traceback_stack(source=source)\n  File \"<template>\", line 2, in top-level template code\n  File \"/opt/app-root/lib64/python3.9/site-packages/jinja2/environment.py\", line 474, in getattr\n    return getattr(obj, attribute)\njinja2.exceptions.UndefinedError: 'dict object' has no attribute 'action_schedule'", "timestamp": "2021-11-22T23:53:36.669755+00:00", "object": {"apiVersion": "poolboy.gpte.redhat.com/v1", "kind": "ResourceHandle", "name": "guid-rmnsz", "uid": "60c6e9e5-1e45-4d18-a8a1-bfe30d96e9b0", "namespace": "lodestar-babylon-operators"}, "severity": "error"}
```

A full exception print out is below

```bash
 default_runtime: {{ merged_vars.__meta__.runtime.default | default(resource_provider_runtime_default) | to_json }} maximum_runtime: {{ merged_vars.__meta__.runtime.maximum | default(resource_provider_runtime_maximum) | to_json }}
ger]: {"message": "Error managing handle", "exc_info": "Traceback (most recent call last):\n       
          File \"operator.py\", line 1672, in manage_handles\n    manage_handle(handle, object_logger)\n  
          
          File \"operator.py\", line 891, in manage_handle\n    resource_definition = provider.resource_definition_from_template(\n  
          
          File \"operator.py\", line 1454, in resource_definition_from_template\n    recursive_process_template_strings(\n  
          
          File \"/opt/app-root/operator/gpte/util.py\", line 169, in recursive_process_template_strings\n    return { k: recursive_process_template_strings(v, template_style, variables) for k, v in template.items() }\n  
          
          File \"/opt/app-root/operator/gpte/util.py\", line 169, in <dictcomp>\n    return { k: recursive_process_template_strings(v, template_style, variables) for k, v in template.items() }\n  
          
          File \"/opt/app-root/operator/gpte/util.py\", line 169, in recursive_process_template_strings\n    return { k: recursive_process_template_strings(v, template_style, variables) for k, v in template.items() }\n  
          
          File \"/opt/app-root/operator/gpte/util.py\", line 169, in <dictcomp>\n    return { k: recursive_process_template_strings(v, template_style, variables) for k, v in template.items() }\n  
          
          File \"/opt/app-root/operator/gpte/util.py\", line 169, in recursive_process_template_strings\n    return { k: recursive_process_template_strings(v, template_style, variables) for k, v in template.items() }\n  File \"/opt/app-root/operator/gpte/util.py\", line 169, in <dictcomp>\n    return { k: recursive_process_template_strings(v, template_style, variables) for k, v in template.items() }\n  
          
          File \"/opt/app-root/operator/gpte/util.py\", line 173, in recursive_process_template_strings\n    return jinja2process(template, template_style, variables)\n  
          
          File \"/opt/app-root/operator/gpte/util.py\", line 165, in jinja2process\n    return j2template.render(variables)\n 
          
           File \"/opt/app-root/lib64/python3.9/site-packages/jinja2/environment.py\", line 1304, in render\n    self.environment.handle_exception()\n  
           
           File \"/opt/app-root/lib64/python3.9/site-packages/jinja2/environment.py\", line 925, in handle_exception\n    raise rewrite_traceback_stack(source=source)\n  File \"<template>\", line 2, in top-level template code\n  File \"/opt/app-root/lib64/python3.9/site-packages/jinja2/environment.py\", line 474, in getattr\n    return getattr(obj, attribute)\njinja2.exceptions.UndefinedError: 'dict object' has no attribute 'action_schedule'", "timestamp": "2021-11-22T23:53:36.669755+00:00", "object": {"apiVersion": "poolboy.gpte.redhat.com/v1", "kind": "ResourceHandle", "name": "guid-rmnsz", "uid": "60c6e9e5-1e45-4d18-a8a1-bfe30d96e9b0", "namespace": "lodestar-babylon-operators"}, "severity": "error"}
```