### PR TITLE
Do not retry in case of missing __meta__.catalog

### DIFF
--- a/roles/agnosticv/tasks/generate_catalog_item.yml
+++ b/roles/agnosticv/tasks/generate_catalog_item.yml
@@ -6,6 +6,7 @@
 
     - include_tasks: include_vars.yml
     - include_tasks: generate_catalog_item_tasks.yml
+      when: merged_vars.__meta__.catalog is defined
 
   rescue:
     - debug:


### PR DESCRIPTION
when a catalog item is broken agnosticv-operator puts it in the list of catalog items to retry.

But if the `__meta__.catalog` part is removed from the broken catalog item, AgnosticV operator will still continue to retry indefinitely.

This change, if applied, fixes that by adding a condition.