### PR TITLE
Add support for requesting status check

### DIFF
--- a/roles/agnosticv/tasks/generate_catalog_item_tasks.yml
+++ b/roles/agnosticv/tasks/generate_catalog_item_tasks.yml
@@ -185,6 +185,7 @@
     definition: "{{ lookup('template', 'governor.yml.j2') | from_yaml }}"
     apply: true
   vars:
+    _entry_points: "{{ merged_vars.__meta__.deployer.entry_points | default({}) }}"
     _name: "{{ catalog_item_name }}"
     _namespace: "{{ anarchy_namespace }}"
 
@@ -199,6 +200,7 @@
     _name: "{{ catalog_item_name }}"
     _namespace: "{{ poolboy_namespace }}"
     _catalog: "{{ vars.merged_vars.__meta__.catalog }}"
+    _entry_points: "{{ merged_vars.__meta__.deployer.entry_points | default({}) }}"
     _governor: "{{ catalog_item_name }}"
 
 - when: >-

--- a/roles/agnosticv/templates/governor.yml.j2
+++ b/roles/agnosticv/templates/governor.yml.j2
@@ -64,10 +64,10 @@ spec:
 
   actions:
 {% for __action in anarchy_governor_standard_actions
- | union((merged_vars.__meta__.deployer.entry_points | default({})).keys() | list)
+ | union(_entry_points.keys() | list)
 %}
 {#   Skip action if entry point is explicitly set to null or empty string. #}
-{%   if merged_vars.__meta__.deployer.entry_points[__action] is not defined or merged_vars.__meta__.deployer.entry_points[__action] | default('', true) != '' %}
+{%   if __action not in _entry_points or _entry_points[__action] | default('', true) != '' %}
     {{ __action }}:
       roles:
 {%     for __role in babylon_anarchy_roles %}

--- a/roles/agnosticv/templates/resource_provider.yml.j2
+++ b/roles/agnosticv/templates/resource_provider.yml.j2
@@ -75,24 +75,43 @@ spec:
   resourceRequiresClaim: {{ merged_vars.__meta__.catalog.provision_requires_request | default(merged_vars.__meta__.catalog.requester_parameters | default([]) | length > 0) | bool | to_json }}
   template:
     enable: true
+
   updateFilters:
-  - allowedOps:
+
+{# Allow changing start schedule if not explicitly disabled #}
+{% if 'start' not in _entry_points or _entry_points.start | default('', true) != '' %}
+  - pathMatch: /spec/vars/action_schedule/start
+    allowedOps:
     - add
     - replace
-    pathMatch: /spec/vars/action_schedule/start
-  - allowedOps:
+  # DEPRECATED - Set set start/stop by setting desired_state
+  - pathMatch: /spec/vars/desired_state
+    allowedOps:
+    - add
+{% endif %}
+
+{# Allow changing stop schedule if not explicitly disabled #}
+{% if 'stop' not in _entry_points or _entry_points.stop | default('', true) != '' %}
+  - pathMatch: /spec/vars/action_schedule/stop
+    allowedOps:
     - add
     - replace
-    pathMatch: /spec/vars/action_schedule/stop
-  - allowedOps:
+{% endif %}
+
+{# Allow requesting status checks if not explicitly disabled #}
+{% if 'status' not in _entry_points or _entry_points.status | default('', true) != '' %}
+  - pathMatch: /spec/vars/check_status_request_timestamp
+    allowedOps:
     - add
     - replace
-    pathMatch: /spec/vars/desired_state
+{% endif %}
+
 {% for parameter in merged_vars.__meta__.catalog.parameters | default([]) %}
 {%   if parameter.allowUpdate | default(false) | bool %}
   - pathMatch: /spec/vars/job_vars/{{ parameter.name }}(/.*)?
 {%   endif %}
 {% endfor %}
+
   validation:
     openAPIV3Schema:
       type: object


### PR DESCRIPTION
- Allow set `check_status_request_timestamp` through ResourceProvider
- Disable ability to trigger start/stop through ResourceProvider if item does not support these actions