### PR TITLE
Fix missing replace operation for desired_state

### DIFF
--- a/roles/agnosticv/templates/resource_provider.yml.j2
+++ b/roles/agnosticv/templates/resource_provider.yml.j2
@@ -86,16 +86,17 @@ spec:
     allowedOps:
     - add
     - replace
-  # DEPRECATED - Set set start/stop by setting desired_state
-  - pathMatch: /spec/vars/desired_state
-    allowedOps:
-    - add
 {% endif %}
 
 {# Allow changing stop schedule if not explicitly disabled #}
 {% if 'stop' not in _entry_points or _entry_points.stop | default('', true) != '' %}
 {%   set _update_filters_empty = false %}
   - pathMatch: /spec/vars/action_schedule/stop
+    allowedOps:
+    - add
+    - replace
+  # Allow updates to action schedule to set the desired state
+  - pathMatch: /spec/vars/desired_state
     allowedOps:
     - add
     - replace


### PR DESCRIPTION
Updating the `desired_state` var should not have been marked as deprecated. The ResourceHandle template needs to be able to update the `desired_state` of AnarchySubjects to cause start/stop.