### PR TITLE
Add support for annotation parameters

### DIFF
--- a/roles/agnosticv/tasks/generate_catalog_item_tasks.yml
+++ b/roles/agnosticv/tasks/generate_catalog_item_tasks.yml
@@ -60,6 +60,18 @@
       | default(merged_vars.__meta__.catalog.description, true)
       | default(default_description)
       }}
+    # Parameters that set variables either do not specify annotation or explicitly set the variable name
+    _annotation_parameters: >-
+      {{ merged_vars.__meta__.catalog.parameters
+      | default([])
+      | json_query('[?annotation]')
+      }}
+    # Parameters that set variables either do not specify annotation or explicitly set the variable name
+    _job_vars_parameters: >-
+      {{ merged_vars.__meta__.catalog.parameters
+      | default([])
+      | json_query('[?(variable || !annotation)]')
+      }}
 
 # Need to get current resource version and force replace because catalog item
 # resources with descriptions are too large to apply.
@@ -188,6 +200,13 @@
     _entry_points: "{{ merged_vars.__meta__.deployer.entry_points | default({}) }}"
     _name: "{{ catalog_item_name }}"
     _namespace: "{{ anarchy_namespace }}"
+    # List of job_vars that are set by parameters and so should not appear in the governor.
+    _job_vars_from_parameters: >-
+      {{ merged_vars.__meta__.catalog.parameters
+      | default([])
+      | json_query('[?(variable || !annotation)].name')
+      | union(merged_vars.__meta__.catalog.requester_parameters | default([]) | json_query('[].name'))
+      }}
 
 - name: Create / Update Poolboy ResourceProvider
   when: None != vars.merged_vars.__meta__.deployer.type | default(None)
@@ -202,6 +221,12 @@
     _catalog: "{{ vars.merged_vars.__meta__.catalog }}"
     _entry_points: "{{ merged_vars.__meta__.deployer.entry_points | default({}) }}"
     _governor: "{{ catalog_item_name }}"
+    # Parameters that set variables either do not specify annotation or explicitly set the variable name
+    _job_vars_parameters: >-
+      {{ merged_vars.__meta__.catalog.parameters
+      | default([])
+      | json_query('[?(variable || !annotation)]')
+      }}
 
 - when: >-
     logstash_report | bool

--- a/roles/agnosticv/templates/governor.yml.j2
+++ b/roles/agnosticv/templates/governor.yml.j2
@@ -26,9 +26,7 @@ spec:
       __meta__:
         tower:
           organization: {{ account | to_json }}
-{% for key in vars.merged_vars if
-  key not in vars.merged_vars.__meta__.catalog.parameters | default([]) | json_query('[].name') and
-  key not in vars.merged_vars.__meta__.catalog.requester_parameters | default([]) | json_query('[].name') %}
+{% for key in vars.merged_vars if key not in _job_vars_from_parameters %}
       {{ key }}: {{ vars.merged_vars[key] | to_json }}
 {% endfor %}
 

--- a/roles/agnosticv/templates/resource_provider.yml.j2
+++ b/roles/agnosticv/templates/resource_provider.yml.j2
@@ -111,9 +111,9 @@ spec:
     - replace
 {% endif %}
 
-{% for parameter in merged_vars.__meta__.catalog.parameters | default([]) %}
+{% for parameter in _job_vars_parameters %}
 {%   if parameter.allowUpdate | default(false) | bool %}
-{%   set _update_filters_empty = false %}
+{%     set _update_filters_empty = false %}
   - pathMatch: /spec/vars/job_vars/{{ parameter.name }}(/.*)?
 {%   endif %}
 {% endfor %}
@@ -155,10 +155,10 @@ spec:
                 job_vars:
                   type: object
                   additionalProperties: false
-{% if merged_vars.__meta__.catalog.parameters | default([]) | length > 0 %}
+{% if _job_vars_parameters | length > 0 %}
                   properties:
-{%   for parameter in merged_vars.__meta__.catalog.parameters %}
+{%   for parameter in _job_vars_parameters %}
                     {{ parameter.name }}: {{ parameter.openAPIV3Schema | default({}) | combine({"description": parameter.description} if "description" in parameter else {}) | to_json }}
 {%   endfor %}
-                  required: {{ merged_vars.__meta__.catalog.parameters | json_query('[?required].name') | to_json }}
+                  required: {{ _job_vars_parameters | json_query('[?required].name') | to_json }}
 {% endif %}

--- a/roles/agnosticv/templates/template.yml.j2
+++ b/roles/agnosticv/templates/template.yml.j2
@@ -25,6 +25,9 @@ objects:
       description: {{ merged_vars.__meta__.catalog.description | d(default_description) | to_json }}
       openshift.io/display-name: {{ merged_vars.__meta__.catalog.display_name| default(_name) | to_json }}
       openshift.io/long-description: {{ merged_vars.__meta__.catalog.long_description | d('') | to_json }}
+{% for param in _annotation_parameters %}
+      {{ param.annotation }}: {{ '${{' ~ param.name ~ '}}' }}
+{% endfor %}
     generateName: {{ _name }}-
   spec:
     resources:
@@ -34,13 +37,14 @@ objects:
         kind: ResourceProvider
         name: {{ _component.item | replace('_', '-') | replace('/', '.') | lower }}.{{ stage }}
         namespace: {{ poolboy_namespace | to_json }}
-{%   if vars.merged_vars.__meta__.catalog.parameters | default([]) | json_query('[?resourceIndexes==`null` || contains(resourceIndexes, `' ~ loop.index0 ~ '`)]') %}
+{#   Only use parameters for component if explicitly declared with resourceIndexes #}
+{%   if _job_vars_parameters | json_query('[?contains(resourceIndexes, `' ~ loop.index0 ~ '`)]') %}
       template:
         spec:
           vars:
             job_vars:
-{%     for param in vars.merged_vars.__meta__.catalog.parameters | default([]) | json_query('[?resourceIndexes==`null` || contains(resourceIndexes, `' ~ loop.index0 ~ '`)]') %}
-              {{ param.name }}: {{ '${{' ~ param.name ~ '}}' }}
+{%     for param in _job_vars_parameters | json_query('[?contains(resourceIndexes, `' ~ loop.index0 ~ '`)]') %}
+              {{ param.variable | default(param.name) }}: {{ '${{' ~ param.name ~ '}}' }}
 {%     endfor %}
 {%   endif %}
 {% endfor %}
@@ -50,13 +54,13 @@ objects:
         kind: ResourceProvider
         name: {{ _name | to_json }}
         namespace: {{ poolboy_namespace | to_json }}
-{%   if vars.merged_vars.__meta__.catalog.parameters | default([]) | json_query('[?resourceIndexes==`null` || contains(resourceIndexes, `"@"`)]') %}
+{%   if _job_vars_parameters | json_query('[?resourceIndexes==`null` || contains(resourceIndexes, `"@"`)]') %}
       template:
         spec:
           vars:
             job_vars:
-{%     for param in vars.merged_vars.__meta__.catalog.parameters | default([]) | json_query('[?resourceIndexes==`null` || contains(resourceIndexes, `"@"`)]') %}
-              {{ param.name }}: {{ '${{' ~ param.name ~ '}}' }}
+{%     for param in _job_vars_parameters | json_query('[?resourceIndexes==`null` || contains(resourceIndexes, `"@"`)]') %}
+              {{ param.variable | default(param.name) }}: {{ '${{' ~ param.name ~ '}}' }}
 {%     endfor %}
 {%   endif %}
 {% endif %}


### PR DESCRIPTION
Some parameters should set annotations instead of or in addition to setting variables for the deployer.

Update to the OpenShift template is provided, though this is not used now in our normal deployment. Parameters are set in the ResourceClaim in the same way shown here but done so through the Babylon catalog UI.