### PR TITLE
Adding OpenAPIV3Schema to AgnosticV CRD

### DIFF
--- a/helm/crds/agnosticvrepos.yaml
+++ b/helm/crds/agnosticvrepos.yaml
@@ -43,6 +43,7 @@ spec:
             description: >-
               Definition of how to create AgnosticV Repo
             type: object
+            x-kubernetes-preserve-unknown-fields: true
             properties:
               url:
                 description: >-
@@ -60,7 +61,7 @@ spec:
                 description: >-
                   Relative path to directory with AgnosticV repo definitions
                 type: string
-              babylon_anarchy_roles:
+              babylonAnarchyRoles:
                 description: >-
                   List of the Babylon Anarchy roles
                 type: array
@@ -82,7 +83,7 @@ spec:
                       description: >-
                         Repository tag
                       type: string
-              babylon_anarchy_collections:
+              babylonAnarchyCollections:
                 description: >-
                   List of the galaxy collections required for Babylon Anarchy
                 type: array
@@ -97,3 +98,6 @@ spec:
                       description: >-
                         Collection version
                       type: string
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true

--- a/helm/crds/agnosticvrepos.yaml
+++ b/helm/crds/agnosticvrepos.yaml
@@ -17,3 +17,83 @@ spec:
     storage: true
     subresources:
       status: {}
+    schema:
+      openAPIV3Schema:
+        description: >-
+          AgnosticVRepo
+        type: object
+        required:
+          - apiVersion
+          - kind
+          - metadata
+          - spec
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+            properties:
+              name:
+                type: string
+                maxLength: 63
+                pattern: ^[a-z0-9A-Z]([a-z0-9A-Z\-._]*[a-z0-9A-Z])?$
+          spec:
+            description: >-
+              Definition of how to create AgnosticV Repo
+            type: object
+            properties:
+              url:
+                description: >-
+                  Url to Git repository containing agnosticv repo definitions
+                type: string
+              ref:
+                description: >-
+                  Git branch
+                type: string
+              sshKey:
+                description: >-
+                  Secret name containing Git access key
+                type: string
+              contextDir:
+                description: >-
+                  Relative path to directory with AgnosticV repo definitions
+                type: string
+              babylon_anarchy_roles:
+                description: >-
+                  List of the Babylon Anarchy roles
+                type: array
+                items:
+                  type: object
+                  required:
+                    - name
+                    - src
+                  properties:
+                    name:
+                      description: >-
+                        Name of the role
+                      type: string
+                    src:
+                      description: >-
+                        Url to Git repository
+                      type: string
+                    version:
+                      description: >-
+                        Repository tag
+                      type: string
+              babylon_anarchy_collections:
+                description: >-
+                  List of the galaxy collections required for Babylon Anarchy
+                type: array
+                items:
+                  type: object
+                  properties:
+                    name:
+                      description: >-
+                        Name of the collection
+                      type: string
+                    version:
+                      description: >-
+                        Collection version
+                      type: string

--- a/helm/crds/agnosticvrepos.yaml
+++ b/helm/crds/agnosticvrepos.yaml
@@ -45,22 +45,21 @@ spec:
             type: object
             x-kubernetes-preserve-unknown-fields: true
             properties:
-              url:
+              babylonAnarchyCollections:
                 description: >-
-                  Url to Git repository containing agnosticv repo definitions
-                type: string
-              ref:
-                description: >-
-                  Git branch
-                type: string
-              sshKey:
-                description: >-
-                  Secret name containing Git access key
-                type: string
-              contextDir:
-                description: >-
-                  Relative path to directory with AgnosticV repo definitions
-                type: string
+                  List of the galaxy collections required for Babylon Anarchy
+                type: array
+                items:
+                  type: object
+                  properties:
+                    name:
+                      description: >-
+                        Name of the collection
+                      type: string
+                    version:
+                      description: >-
+                        Collection version
+                      type: string
               babylonAnarchyRoles:
                 description: >-
                   List of the Babylon Anarchy roles
@@ -83,21 +82,22 @@ spec:
                       description: >-
                         Repository tag
                       type: string
-              babylonAnarchyCollections:
+              contextDir:
                 description: >-
-                  List of the galaxy collections required for Babylon Anarchy
-                type: array
-                items:
-                  type: object
-                  properties:
-                    name:
-                      description: >-
-                        Name of the collection
-                      type: string
-                    version:
-                      description: >-
-                        Collection version
-                      type: string
+                  Relative path to directory with AgnosticV repo definitions
+                type: string
+              ref:
+                description: >-
+                  Git branch
+                type: string
+              sshKey:
+                description: >-
+                  Secret name containing Git access key
+                type: string
+              url:
+                description: >-
+                  Url to Git repository containing agnosticv repo definitions
+                type: string
           status:
             type: object
             x-kubernetes-preserve-unknown-fields: true


### PR DESCRIPTION
Following error occurs while `anosticv-operator` install to OCP cluster:

```
CustomResourceDefinition.apiextensions.k8s.io "agnosticvrepos.gpte.redhat.com" is invalid: spec.versions[0].schema.openAPIV3Schema: Required value: schemas are required
```
I think the reason was in version update from `v1beta1` to `v1`. I've created schema based on my understanding of the `agnosticv-operator`.

