### PR TITLE
Add ability to propagate all provision data in a single variable

### DIFF
--- a/roles/agnosticv/templates/resource_provider.yml.j2
+++ b/roles/agnosticv/templates/resource_provider.yml.j2
@@ -63,8 +63,13 @@ spec:
 {% for _component in vars.merged_vars.__meta__.components | default([]) %}
 {%   set _component_index = loop.index0 %}
 {%   for _propagate_item in _component.propagate_provision_data | default([]) %}
+{%     if _propagate_item.name | default('*') == '*' %}
+          {{ _propagate_item.var }}: >-
+            {{ '{{ provision_data_' ~ _component_index ~ ' | object }}' }}
+{%     else %}
           {{ _propagate_item.var }}: >-
             {{ '{{ provision_data_' ~ _component_index ~ '.' ~ _propagate_item.name ~ '}}' }}
+{%     endif %}
 {%   endfor %}
 {% endfor %}
 {% if merged_vars.__meta__.catalog.requester_parameters | default([]) | length > 0 %}


### PR DESCRIPTION
Add ability to propagate all provision data in a single variable. Ex:
```
__meta__:
  components:
    - name: aws-sandbox-a
      display_name: AWS OpenShift A
      item: sandboxes-gpte/SANDBOX_OCP49
      propagate_provision_data:
        - var: openshift_aws_a
    - name: aws-sandbox-b
      display_name: AWS OpenShift B
      item: sandboxes-gpte/SANDBOX_OCP49
      propagate_provision_data:
        - var: openshift_aws_b
```