### PR TITLE
Change to always update action schedule even when start/stop are not supported

### DIFF
--- a/roles/agnosticv/templates/resource_provider.yml.j2
+++ b/roles/agnosticv/templates/resource_provider.yml.j2
@@ -85,20 +85,10 @@ spec:
     enable: true
 
   updateFilters:
-{% set _update_filters_empty = true %}
-
-{# Allow changing start schedule if not explicitly disabled #}
-{% if not _actions.start.disable | default(false) | bool %}
-{%   set _update_filters_empty = false %}
   - pathMatch: /spec/vars/action_schedule/start
     allowedOps:
     - add
     - replace
-{% endif %}
-
-{# Allow changing stop schedule if not explicitly disabled #}
-{% if not _actions.stop.disable | default(false) | bool %}
-{%   set _update_filters_empty = false %}
   - pathMatch: /spec/vars/action_schedule/stop
     allowedOps:
     - add
@@ -108,7 +98,6 @@ spec:
     allowedOps:
     - add
     - replace
-{% endif %}
 
 {# Allow requesting status checks if not explicitly disabled #}
 {% if not _actions.status.disable | default(false) | bool %}
@@ -125,10 +114,6 @@ spec:
   - pathMatch: /spec/vars/job_vars/{{ parameter.name }}(/.*)?
 {%   endif %}
 {% endfor %}
-
-{% if _update_filters_empty %}
-    []
-{% endif %}
 
   validation:
     openAPIV3Schema:


### PR DESCRIPTION
The current behavior is rather confusing as the action schedule ends up in the AnarchySubject but is then never updated. Better to update even when it isn't used.